### PR TITLE
feat: added test results output

### DIFF
--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -103,7 +103,7 @@ jobs:
       matrix:
         # run copies of the current job in parallel
         containers: [1, 2]
-    if: needs.check-record-key.outputs.record-key-exists == 'true'
+    if: always() # needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -138,18 +138,24 @@ jobs:
         run: |
           echo Cypress test results: ${{ steps.cypress.outputs.testResultsObject }}
 
-      # parse the `testResultsObject` output as JSON
+      # parse the `testResultsObject` output as JSON.
+      # Note that the output is a string and empty if there is a custom command passed to the action and the command runs through CLI
       - name: Parse the Cypress test results output
         uses: actions/github-script@v6.4.1
         with:
           script: |
+            if (${{ steps.cypress.outputs.testResultsObject }} == "") {
+              console.log('No test results found')
+              return
+            }
+
             const testResults = JSON.parse('${{ steps.cypress.outputs.testResultsObject }}')
             console.log("Success: " + testResults.success)
             console.log("TotalPassed: " + testResults.totalPassed)
             console.log("TotalFailed: " + testResults.totalFailed)
             console.log("TotalPending: " + testResults.totalPending)
             console.log("TotalSkipped: " + testResults.totalSkipped)
-            console.log("TotalDuration: " + testResults.totalDuration)
+            console.log("TotalDuration: " + testResults.totalDuration) 
 
   group:
     runs-on: ubuntu-22.04

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -133,6 +133,24 @@ jobs:
           echo Cypress finished with: ${{ steps.cypress.outcome }}
           echo See results at ${{ steps.cypress.outputs.resultsUrl }}
 
+      # print the `testResultsObject` output directly as string
+      - name: Print Cypress test results output
+        run: |
+          echo Cypress test results: ${{ steps.cypress.outputs.testResultsObject }}
+
+      # parse the `testResultsObject` output as JSON
+      - name: Parse the Cypress test results output
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const testResults = JSON.parse('${{ steps.cypress.outputs.testResultsObject }}')
+            console.log("Success: " + testResults.success)
+            console.log("TotalPassed: " + testResults.totalPassed)
+            console.log("TotalFailed: " + testResults.totalFailed)
+            console.log("TotalPending: " + testResults.totalPending)
+            console.log("TotalSkipped: " + testResults.totalSkipped)
+            console.log("TotalDuration: " + testResults.totalDuration)
+
   group:
     runs-on: ubuntu-22.04
     needs: [check-record-key]

--- a/.github/workflows/example-recording.yml
+++ b/.github/workflows/example-recording.yml
@@ -103,7 +103,7 @@ jobs:
       matrix:
         # run copies of the current job in parallel
         containers: [1, 2]
-    if: always() # needs.check-record-key.outputs.record-key-exists == 'true'
+    if: needs.check-record-key.outputs.record-key-exists == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ examples/**/.yarn/*
 !examples/**/.yarn/releases
 !examples/**/.yarn/sdks
 !examples/**/.yarn/versions
+
+.idea

--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,34 @@ The GitHub step output `dashboardUrl` is deprecated. Cypress Dashboard is now [C
 
 **Note:** every GitHub workflow step can have `outcome` and `conclusion` properties. See the GitHub [Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts) documentation section [steps context](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context). In particular, the `outcome` or `conclusion` value can be `success`, `failure`, `cancelled`, or `skipped` which you can use in any following steps.
 
+It also sets a step output `testResultsObject` which contains a stringified test results JSON object.  
+In order to use it you should parse the string into an object.  
+Ex:
+```yaml
+...
+  steps:
+    - name: Parse results
+      uses: actions/github-script@v6.4.1
+      with:
+        script: |
+          const testResults = JSON.parse('${{ steps.cypress-run.outputs.testResultsObject }}')
+          console.log(testResults.success)
+          console.log(testResults.totalPassed)
+          ...
+```
+Example structure of the JSON object:
+```json
+{
+  "success": true,
+  "totalPassed": 5,
+  "totalFailed": 2,
+  "totalPending": 0,
+  "totalSkipped": 1,
+  "totalDuration": 25
+}
+```
+**Note:** `totalDuration` is expressed in seconds.
+
 ### Print Cypress info
 
 Sometimes you might want to print Cypress and OS information, like the list of detected browsers. You can use the [`cypress info`](https://on.cypress.io/command-line#cypress-info) command for this.

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,8 @@ outputs:
     description: 'Cypress Cloud URL if the run was recorded (deprecated)'
   resultsUrl:
     description: 'Cypress Cloud URL if the run was recorded'
+  testResultsObject:
+    description: 'Cypress test results stringifyed JSON object'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -75197,7 +75197,7 @@ const generateOutputTestResultsObject = (testResults) => {
     totalFailed: testResults.totalFailed,
     totalPending: testResults.totalPending,
     totalSkipped: testResults.totalSkipped,
-    totalDuration: testResults.totalDuration / 1000 + 's' || 0
+    totalDuration: testResults.totalDuration / 1000 || ''
   }
 
   core.setOutput('testResultsObject', JSON.stringify(outputObject))

--- a/dist/index.js
+++ b/dist/index.js
@@ -75151,15 +75151,9 @@ const isSummaryEnabled = () => {
 }
 
 const generateSummary = async (testResults) => {
-  console.log(
-    'Generating summary: %s',
-    isSummaryEnabled() ? 'yes' : 'no'
-  )
   if (!isSummaryEnabled()) {
     return testResults
   }
-
-  console.log('after generating summary')
 
   const headers = [
     { data: 'Result', header: true },
@@ -75197,10 +75191,6 @@ const generateSummary = async (testResults) => {
 }
 
 const generateOutputTestResultsObject = (testResults) => {
-  console.log('Generating output test results object')
-  console.log(JSON.stringify(outputObject))
-  console.log(testResults)
-
   const outputObject = {
     success: testResults.totalFailed === 0,
     totalPassed: testResults.totalPassed,

--- a/dist/index.js
+++ b/dist/index.js
@@ -75139,6 +75139,7 @@ const runTests = async () => {
   process.chdir(workingDirectory)
   return cypress
     .run(cypressOptions)
+    .then(generateOutputTestResultsObject)
     .then(generateSummary)
     .then(onTestsFinished, onTestsError)
 }
@@ -75150,9 +75151,15 @@ const isSummaryEnabled = () => {
 }
 
 const generateSummary = async (testResults) => {
+  console.log(
+    'Generating summary: %s',
+    isSummaryEnabled() ? 'yes' : 'no'
+  )
   if (!isSummaryEnabled()) {
     return testResults
   }
+
+  console.log('after generating summary')
 
   const headers = [
     { data: 'Result', header: true },
@@ -75185,6 +75192,25 @@ const generateSummary = async (testResults) => {
       testResults.runUrl || ''
     )
     .write()
+
+  return testResults
+}
+
+const generateOutputTestResultsObject = (testResults) => {
+  console.log('Generating output test results object')
+  console.log(JSON.stringify(outputObject))
+  console.log(testResults)
+
+  const outputObject = {
+    success: testResults.totalFailed === 0,
+    totalPassed: testResults.totalPassed,
+    totalFailed: testResults.totalFailed,
+    totalPending: testResults.totalPending,
+    totalSkipped: testResults.totalSkipped,
+    totalDuration: testResults.totalDuration / 1000 + 's' || 0
+  }
+
+  core.setOutput('testResultsObject', JSON.stringify(outputObject))
 
   return testResults
 }

--- a/index.js
+++ b/index.js
@@ -846,7 +846,7 @@ const generateOutputTestResultsObject = (testResults) => {
     totalFailed: testResults.totalFailed,
     totalPending: testResults.totalPending,
     totalSkipped: testResults.totalSkipped,
-    totalDuration: testResults.totalDuration / 1000 + 's' || ''
+    totalDuration: testResults.totalDuration / 1000 || ''
   }
 
   core.setOutput('testResultsObject', JSON.stringify(outputObject))

--- a/index.js
+++ b/index.js
@@ -788,6 +788,7 @@ const runTests = async () => {
   process.chdir(workingDirectory)
   return cypress
     .run(cypressOptions)
+    .then(generateOutputTestResultsObject)
     .then(generateSummary)
     .then(onTestsFinished, onTestsError)
 }
@@ -799,9 +800,15 @@ const isSummaryEnabled = () => {
 }
 
 const generateSummary = async (testResults) => {
+  console.log(
+    'Generating summary: %s',
+    isSummaryEnabled() ? 'yes' : 'no'
+  )
   if (!isSummaryEnabled()) {
     return testResults
   }
+
+  console.log('after generating summary')
 
   const headers = [
     { data: 'Result', header: true },
@@ -834,6 +841,25 @@ const generateSummary = async (testResults) => {
       testResults.runUrl || ''
     )
     .write()
+
+  return testResults
+}
+
+const generateOutputTestResultsObject = (testResults) => {
+  console.log('Generating output test results object')
+  console.log(JSON.stringify(outputObject))
+  console.log(testResults)
+
+  const outputObject = {
+    success: testResults.totalFailed === 0,
+    totalPassed: testResults.totalPassed,
+    totalFailed: testResults.totalFailed,
+    totalPending: testResults.totalPending,
+    totalSkipped: testResults.totalSkipped,
+    totalDuration: testResults.totalDuration / 1000 + 's' || ''
+  }
+
+  core.setOutput('testResultsObject', JSON.stringify(outputObject))
 
   return testResults
 }

--- a/index.js
+++ b/index.js
@@ -800,15 +800,9 @@ const isSummaryEnabled = () => {
 }
 
 const generateSummary = async (testResults) => {
-  console.log(
-    'Generating summary: %s',
-    isSummaryEnabled() ? 'yes' : 'no'
-  )
   if (!isSummaryEnabled()) {
     return testResults
   }
-
-  console.log('after generating summary')
 
   const headers = [
     { data: 'Result', header: true },
@@ -846,10 +840,6 @@ const generateSummary = async (testResults) => {
 }
 
 const generateOutputTestResultsObject = (testResults) => {
-  console.log('Generating output test results object')
-  console.log(JSON.stringify(outputObject))
-  console.log(testResults)
-
   const outputObject = {
     success: testResults.totalFailed === 0,
     totalPassed: testResults.totalPassed,


### PR DESCRIPTION
Added a `testResultsObject` output that contains a strigified JSON object with the test results.  


**Object**
```json
{
  "success": true,
  "totalPassed": 5,
  "totalFailed": 2,
  "totalPending": 0,
  "totalSkipped": 1,
  "totalDuration": 25
}
```

**Stringified**
```
"{\"success\": true,\"totalPassed\": 5,\"totalFailed\",\"totalPending\": 0,\"totalSkipped\": 1,\"totalDuration\": 25}"
```

**Usage**

```yaml
...
  steps:
    - name: Parse results
      uses: actions/github-script@v6.4.1
      with:
        script: |
          const testResults = JSON.parse('${{ steps.cypress-run.outputs.testResultsObject }}')
          console.log(testResults.success)
          console.log(testResults.totalPassed)
          ...
```
